### PR TITLE
feat: Enhance navigation and data handling for LM Rental Evidence

### DIFF
--- a/lib/application/core/router/pages.dart
+++ b/lib/application/core/router/pages.dart
@@ -15,6 +15,8 @@ class Pages {
   static const routeRoAssetsList = "ro-assets-list";
   static const routeRentalEvidence = "rentalevidence";
   static const routeLmRentalEvidences = "lm-rental-evidences";
+  static const routeLmSalesEvidences = "lm-sales-evidences";
+  static const routeLmPastValuations = "lm-past-valuations";
   static const routeI2RentalEvidence = "i2rentalevidence";
   static const routeMapScreen = "routemap";
   static const routeAssetMapScreen = "asset-map-screen";

--- a/lib/application/core/router/routes.dart
+++ b/lib/application/core/router/routes.dart
@@ -19,6 +19,8 @@ import 'package:land_asset_valuation/application/pages/dashboard/dashboard_view.
 import 'package:land_asset_valuation/application/pages/inspectionReport/inspection_report_view.dart';
 import 'package:land_asset_valuation/application/pages/rental_evidence/rental_evidence_view.dart';
 import 'package:land_asset_valuation/application/pages/LMRentalEvidences/lm_rental_evidences_view.dart';
+import 'package:land_asset_valuation/application/pages/LMSalesEvidences/lm_sales_evidences_view.dart';
+import 'package:land_asset_valuation/application/pages/LMPastValuations/lm_past_valuations_view.dart';
 import 'package:land_asset_valuation/application/pages/pastValuation/past_valuation_view.dart';
 import 'package:land_asset_valuation/application/pages/settingsScreen/settings_screen.dart';
 import 'package:land_asset_valuation/application/pages/signIn/signin_view.dart';
@@ -305,6 +307,37 @@ class AppRouter {
               return NoTransitionPage(
                 key: state.pageKey,
                 child: LmRentalEvidencesView(),
+              );
+            },
+          ),
+          GoRoute(
+            path: Pages.routeLmSalesEvidences.toPath(),
+            name: Pages.routeLmSalesEvidences.toPathName(),
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const LmSalesEvidencesView(),
+              );
+            },
+          ),
+          GoRoute(
+            path: Pages.routeLmPastValuations.toPath(),
+            name: Pages.routeLmPastValuations.toPathName(),
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: FutureBuilder<MasterDataResponse>(
+                  future: GetIt.I<GetMasterDataUseCase>()(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Center(child: CircularProgressIndicator());
+                    } else if (snapshot.hasError) {
+                      return Center(child: Text('Failed to load master data'));
+                    } else {
+                      return LmPastValuationsView(masterData: snapshot.data!);
+                    }
+                  },
+                ),
               );
             },
           ),

--- a/lib/application/core/widgets/tableForLM/table_scaffold_LM.dart
+++ b/lib/application/core/widgets/tableForLM/table_scaffold_LM.dart
@@ -10,6 +10,8 @@ import 'package:land_asset_valuation/data/models/paginated_response.dart';
 import 'package:land_asset_valuation/data/models/land_miscellaneous_master_file_model.dart';
 import 'package:land_asset_valuation/domain/repositories/land_miscellaneous_repository.dart';
 import 'package:land_asset_valuation/data/services/building_service.dart';
+import 'package:land_asset_valuation/data/services/rental_evidence_service.dart';
+import 'package:land_asset_valuation/injection.dart';
 
 class TableScaffoldLM extends StatefulWidget {
   final int initialPageSize;
@@ -44,6 +46,8 @@ class TableScaffoldLMState extends State<TableScaffoldLM> {
   int?
       _previousTotalCount; // Cache previous count to prevent unnecessary callbacks
   final BuildingService _buildingService = BuildingService();
+  final RentalEvidenceService _rentalEvidenceService =
+      injection<RentalEvidenceService>();
 
   @override
   void initState() {
@@ -391,22 +395,31 @@ class TableScaffoldLMState extends State<TableScaffoldLM> {
                                         color: colors(context).colorGrey8!,
                                         iconName: PhosphorIconsRegular.eye,
                                         onPressed: () async {
-                                          // Clear buildings for this master file when View button is tapped
+                                          // Clear both buildings and rental evidences for this master file when View button is tapped
                                           debugPrint(
                                               "🗑️ LM Table: View button tapped for master file ${plan.masterFileNo}");
                                           debugPrint(
-                                              "   Clearing existing buildings for this master file...");
+                                              "   Clearing existing buildings and rental evidences for this master file...");
 
                                           try {
+                                            // Clear buildings
                                             await _buildingService
                                                 .clearBuildingsForMasterFile(
                                                     plan.masterFileNo
                                                         .toString());
                                             debugPrint(
                                                 "✅ LM Table: Successfully cleared buildings for master file ${plan.masterFileNo}");
+
+                                            // Clear rental evidences
+                                            await _rentalEvidenceService
+                                                .clearRentalEvidencesForMasterFile(
+                                                    plan.masterFileNo
+                                                        .toString());
+                                            debugPrint(
+                                                "✅ LM Table: Successfully cleared rental evidences for master file ${plan.masterFileNo}");
                                           } catch (e) {
                                             debugPrint(
-                                                "❌ LM Table: Error clearing buildings: $e");
+                                                "❌ LM Table: Error clearing data: $e");
                                           }
 
                                           // Navigate to map screen

--- a/lib/application/pages/AssetMapScreen/asset_map_screen.dart
+++ b/lib/application/pages/AssetMapScreen/asset_map_screen.dart
@@ -309,18 +309,58 @@ class _AssetMapScreenState extends State<AssetMapScreen> {
     debugPrint("MapScreen: Navigating to form for type: $type");
     String? targetPath;
 
+    // Get the source context from route parameters
+    final String source =
+        GoRouterState.of(context).uri.queryParameters['source'] ?? '';
+
     switch (type) {
       case MapMarkerLoader.markerTypeRental:
-        targetPath = Pages.routeRentalEvidence.toPath();
+        // Context-aware navigation for Rental Evidence
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmRentalEvidences.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Rental Evidence (source: $source)");
+        } else {
+          targetPath = Pages.routeRentalEvidence.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Rental Evidence (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeSales:
-        targetPath = Pages.routeLaSalesEvidence.toPath();
+        // Context-aware navigation for Sales Evidence
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmSalesEvidences.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Sales Evidence (source: $source)");
+        } else {
+          targetPath = Pages.routeLaSalesEvidence.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Sales Evidence (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeValuations:
-        targetPath = Pages.routePastValuation.toPath();
+        // Context-aware navigation for Past Valuations
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmPastValuations.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Past Valuations (source: $source)");
+        } else {
+          targetPath = Pages.routePastValuation.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Past Valuations (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeBuildingRates:
-        targetPath = Pages.routeLaBuildingRates.toPath();
+        // Context-aware navigation for Building Rates
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmBuildingRates.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Building Rates (source: $source)");
+        } else {
+          targetPath = Pages.routeLaBuildingRates.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Building Rates (source: $source)");
+        }
         break;
       default:
         debugPrint("MapScreen: Cannot navigate: Unknown data type '$type'.");

--- a/lib/application/pages/LMPastValuations/lm_past_valuations_view.dart
+++ b/lib/application/pages/LMPastValuations/lm_past_valuations_view.dart
@@ -32,6 +32,50 @@ class _LmPastValuationsViewState extends BasePageState<LmPastValuationsView> {
   final _formKey = GlobalKey<FormState>();
   List<dynamic> uploadedImages = [];
 
+  // Controllers for coordinate fields
+  final _longitudeController = TextEditingController();
+  final _latitudeController = TextEditingController();
+  final _masterFileController = TextEditingController();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _extractNavigationData();
+  }
+
+  void _extractNavigationData() {
+    final args =
+        ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
+
+    if (args != null) {
+      // Extract coordinates from navigation arguments
+      final lat = args['lat']?.toString();
+      final lng = args['lng']?.toString();
+
+      if (lat != null && lat.isNotEmpty) {
+        _latitudeController.text = lat;
+      }
+
+      if (lng != null && lng.isNotEmpty) {
+        _longitudeController.text = lng;
+      }
+
+      // Extract master file data if available
+      final masterFileRefNo = args['masterFileRefNo']?.toString();
+      if (masterFileRefNo != null && masterFileRefNo.isNotEmpty) {
+        _masterFileController.text = masterFileRefNo;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _longitudeController.dispose();
+    _latitudeController.dispose();
+    _masterFileController.dispose();
+    super.dispose();
+  }
+
   void _onImagePicked(File? file) {
     if (file != null) {
       setState(() {
@@ -183,6 +227,7 @@ class _LmPastValuationsViewState extends BasePageState<LmPastValuationsView> {
                     LabeledTextField(
                       label: AppString.masterFilerefno.localize(context)!,
                       placeholder: "Metro/2/LM/123",
+                      controller: _masterFileController,
                     ),
                     LabeledTextField(
                       label: AppString.fileNoGnDivision.localize(context)!,
@@ -262,6 +307,7 @@ class _LmPastValuationsViewState extends BasePageState<LmPastValuationsView> {
                     LabeledTextField(
                       label: AppString.locationLongitude.localize(context)!,
                       placeholder: "6.123456789",
+                      controller: _longitudeController,
                       validator: (value) =>
                           LmPastValuationsValidator.optionalNumeric(
                               value, 255, "Longitude"),
@@ -269,6 +315,7 @@ class _LmPastValuationsViewState extends BasePageState<LmPastValuationsView> {
                     LabeledTextField(
                       label: AppString.locationLatitude.localize(context)!,
                       placeholder: "6.123456789",
+                      controller: _latitudeController,
                       validator: (value) =>
                           LmPastValuationsValidator.optionalNumeric(
                               value, 255, "Latitude"),

--- a/lib/application/pages/LMRentalEvidences/cubit/lm_rental_evidences_cubit.dart
+++ b/lib/application/pages/LMRentalEvidences/cubit/lm_rental_evidences_cubit.dart
@@ -16,14 +16,14 @@ class LmRentalEvidencesCubit
   }) : super(LmRentalEvidencesInitial());
 
   Future<void> sendLmRentalEvidence({
-    required String masterFileId,
+    required int landMiscellaneousMasterFileId,
     required String masterFileRefNo,
     required String assessmentNo,
     required String owner,
     required String occupier,
     required String description,
-    required String floorRateSQFT,
-    required String ratePerSqft,
+    required String floorRate,
+    required String ratePer,
     required String ratePerMonth,
     required String locationLongitude,
     required String locationLatitude,
@@ -35,14 +35,14 @@ class LmRentalEvidencesCubit
 
     // Create the LM rental evidence model
     final reportModel = LmRentalEvidencesModel(
-      masterFileId: masterFileId,
+      landMiscellaneousMasterFileId: landMiscellaneousMasterFileId,
       masterFileRefNo: masterFileRefNo,
       assessmentNo: assessmentNo,
       owner: owner,
       occupier: occupier,
       description: description,
-      floorRateSQFT: floorRateSQFT,
-      ratePerSqft: ratePerSqft,
+      floorRate: floorRate,
+      ratePer: ratePer,
       ratePerMonth: ratePerMonth,
       locationLongitude: locationLongitude,
       locationLatitude: locationLatitude,
@@ -53,7 +53,8 @@ class LmRentalEvidencesCubit
 
     // Debug: Print in the cubit
     print('======= LM RENTAL EVIDENCES CUBIT: CREATING MODEL =======');
-    print('Master File ID: ${reportModel.masterFileId}');
+    print(
+        'Land Miscellaneous Master File ID: ${reportModel.landMiscellaneousMasterFileId}');
     print('Assessment No: ${reportModel.assessmentNo}');
     print('Owner: ${reportModel.owner}');
     print('Data being prepared for API call...');

--- a/lib/application/pages/LMRentalEvidences/lm_rental_evidences_view.dart
+++ b/lib/application/pages/LMRentalEvidences/lm_rental_evidences_view.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:land_asset_valuation/app/base_view.dart';
 import 'package:land_asset_valuation/app/cubit/base_cubit.dart';
 import 'package:land_asset_valuation/app/cubit/base_state.dart';
 import 'package:land_asset_valuation/application/core/configurations/app_config.dart';
-import 'package:land_asset_valuation/application/core/router/pages.dart';
 import 'package:land_asset_valuation/application/core/utils/app_colors/light_color_list.dart';
 import 'package:land_asset_valuation/application/core/utils/app_colors/theme_data.dart';
 import 'package:land_asset_valuation/application/core/utils/app_strings.dart';
@@ -57,6 +58,132 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
   List<dynamic> uploadedImages = []; // Track submission state
   bool _isSubmitting = false;
 
+  // Master file data for breadcrumb
+  String? _masterFileNo;
+  String? _masterFileId;
+
+  // Unique identifier for this specific rental evidence marker
+  String? _markerId;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _extractNavigationData();
+    // Use a post-frame callback to ensure data loading happens after the widget is built
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadSavedDataIfExists();
+    });
+  }
+
+  void _extractNavigationData() {
+    final GoRouterState state = GoRouterState.of(context);
+    final queryParams = state.uri.queryParameters;
+
+    // Extract master file data
+    _masterFileNo = queryParams['masterFileNo'];
+    _masterFileId = queryParams['masterFileId']; // Store master file ID
+    final masterFileRefNo = queryParams['masterFileRefNo'];
+
+    // Extract coordinates from query parameters
+    final lat = queryParams['latitude'];
+    final lng = queryParams['longitude'];
+
+    if (lat != null && lat.isNotEmpty) {
+      _latitudeController.text = lat;
+    }
+
+    if (lng != null && lng.isNotEmpty) {
+      _longitudeController.text = lng;
+    }
+
+    // Generate unique marker ID based on coordinates
+    if (lat != null && lng != null && lat.isNotEmpty && lng.isNotEmpty) {
+      // Create a unique identifier using coordinates (rounded to avoid floating point precision issues)
+      final roundedLat = double.parse(lat).toStringAsFixed(6);
+      final roundedLng = double.parse(lng).toStringAsFixed(6);
+      _markerId = '${roundedLat}_${roundedLng}';
+      debugPrint('Generated marker ID: $_markerId');
+    } else {
+      // Fallback to timestamp if coordinates are not available
+      _markerId = DateTime.now().millisecondsSinceEpoch.toString();
+      debugPrint('Generated fallback marker ID: $_markerId');
+    }
+
+    // Pre-fill master file reference number if available
+    if (masterFileRefNo != null && masterFileRefNo.isNotEmpty) {
+      _masterFileRefNoController.text = masterFileRefNo;
+      debugPrint('Pre-filled masterFileRefNo from URL: $masterFileRefNo');
+    }
+
+    debugPrint(
+        "LmRentalEvidences: Extracted data - MasterFileNo: $_masterFileNo, MasterFileRefNo: $masterFileRefNo, Coordinates: ($lat, $lng), MarkerID: $_markerId");
+  }
+
+  /// Attempts to load previously saved data for this specific marker
+  Future<void> _loadSavedDataIfExists() async {
+    if (_masterFileNo == null || _markerId == null) return;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      // Use both master file number and marker ID to create unique storage key
+      final String key = 'lm_rental_evidence_${_masterFileNo}_$_markerId';
+      final String? savedDataJson = prefs.getString(key);
+
+      if (savedDataJson != null) {
+        final Map<String, dynamic> savedData = jsonDecode(savedDataJson);
+
+        debugPrint(
+            'LM Rental Evidence: Found saved data for masterFileNo: $_masterFileNo, markerID: $_markerId');
+        debugPrint('Saved masterFileRefNo: ${savedData['masterFileRefNo']}');
+        debugPrint(
+            'Current masterFileRefNoController: ${_masterFileRefNoController.text}');
+
+        // Load all saved data (we can overwrite since this is the same marker)
+        _assessmentNoController.text = savedData['assessmentNo'] ?? '';
+        _ownerController.text = savedData['owner'] ?? '';
+        _occupierController.text = savedData['occupier'] ?? '';
+        _descriptionController.text = savedData['description'] ?? '';
+        _floorRateController.text = savedData['floorRate'] ?? '';
+        _ratePerSqftController.text = savedData['ratePerSqft'] ?? '';
+        _ratePerMonthController.text = savedData['ratePerMonth'] ?? '';
+        _headOfTermsController.text = savedData['headOfTerms'] ?? '';
+        _situationController.text = savedData['situation'] ?? '';
+        _remarksController.text = savedData['remarks'] ?? '';
+
+        // Load coordinates (these should match the current coordinates from URL)
+        final savedLng = savedData['longitude'] ?? '';
+        final savedLat = savedData['latitude'] ?? '';
+        if (savedLng.isNotEmpty) {
+          _longitudeController.text = savedLng;
+        }
+        if (savedLat.isNotEmpty) {
+          _latitudeController.text = savedLat;
+        }
+
+        // Load master file ref no if available
+        final savedMasterFileRefNo = savedData['masterFileRefNo'] ?? '';
+        if (savedMasterFileRefNo.isNotEmpty) {
+          _masterFileRefNoController.text = savedMasterFileRefNo;
+          debugPrint(
+              'Loaded masterFileRefNo from saved data: ${_masterFileRefNoController.text}');
+        }
+
+        debugPrint(
+            'LM Rental Evidence: Loaded previously saved data for this specific marker');
+
+        // Force a rebuild to update the UI with loaded data
+        if (mounted) {
+          setState(() {});
+        }
+      } else {
+        debugPrint(
+            'LM Rental Evidence: No saved data found for masterFileNo: $_masterFileNo, markerID: $_markerId');
+      }
+    } catch (e) {
+      debugPrint('Error loading saved data: $e');
+    }
+  }
+
   @override
   void dispose() {
     // Dispose all controllers
@@ -102,6 +229,124 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
     );
   }
 
+  // Local save method - validates and saves locally without backend submission
+  void _saveLocally() {
+    debugPrint('=== Save button pressed ===');
+    debugPrint('Master File No: $_masterFileNo');
+    debugPrint('Marker ID: $_markerId');
+    debugPrint(
+        'Master File Ref No Controller text: "${_masterFileRefNoController.text}"');
+    debugPrint(
+        'Master File Ref No Controller text length: ${_masterFileRefNoController.text.length}');
+    debugPrint(
+        'Is Master File Ref No empty: ${_masterFileRefNoController.text.isEmpty}');
+
+    if (_formKey.currentState!.validate()) {
+      debugPrint('Form validation PASSED');
+      // All form validation passed, now perform additional data type validation
+      try {
+        // Create a map to track all validation issues
+        Map<String, String> validationErrors = {};
+
+        // Validate numeric fields
+        _validateNumericField(
+            _floorRateController.text, 'Floor Rate', validationErrors);
+        _validateNumericField(
+            _ratePerSqftController.text, 'Rate Per Sqft', validationErrors);
+        _validateNumericField(
+            _ratePerMonthController.text, 'Rate Per Month', validationErrors);
+
+        // Validate coordinate fields
+        _validateCoordinateField(
+            _longitudeController.text, 'Longitude', validationErrors);
+        _validateCoordinateField(
+            _latitudeController.text, 'Latitude', validationErrors);
+
+        // If there are validation errors, show them and stop
+        if (validationErrors.isNotEmpty) {
+          String errorMessage = 'Validation errors:\n';
+          validationErrors.forEach((field, error) {
+            errorMessage += '• $field: $error\n';
+          });
+          _showErrorMessage(errorMessage);
+          return;
+        }
+
+        // Double-check numeric conversions
+        try {
+          // Ensure these are valid numbers
+          double.parse(_floorRateController.text);
+          double.parse(_ratePerSqftController.text);
+          double.parse(_ratePerMonthController.text);
+          double.parse(_longitudeController.text);
+          double.parse(_latitudeController.text);
+        } catch (e) {
+          _showErrorMessage('Error converting numeric values: $e');
+          return;
+        }
+
+        // Create form data map for local storage
+        final formData = {
+          'assessmentNo': _assessmentNoController.text.trim(),
+          'masterFileRefNo': _masterFileRefNoController.text.trim(),
+          'owner': _ownerController.text.trim(),
+          'occupier': _occupierController.text.trim(),
+          'description': _descriptionController.text.trim(),
+          'floorRate': _floorRateController.text.trim(),
+          'ratePerSqft': _ratePerSqftController.text.trim(),
+          'ratePerMonth': _ratePerMonthController.text.trim(),
+          'longitude': _longitudeController.text.trim(),
+          'latitude': _latitudeController.text.trim(),
+          'headOfTerms': _headOfTermsController.text.trim(),
+          'situation': _situationController.text.trim(),
+          'remarks': _remarksController.text.trim(),
+        };
+
+        // Save data locally for this specific marker
+        _saveDataLocally(formData);
+      } catch (e) {
+        _showErrorMessage('Error saving form data locally: $e');
+      }
+    } else {
+      debugPrint('Form validation FAILED');
+      _showErrorMessage('Please fix the errors in the form');
+    }
+  }
+
+  /// Saves the form data to local storage for this specific marker
+  Future<void> _saveDataLocally(Map<String, String> data) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      // Create a map with form data and metadata
+      final localData = {
+        'masterFileNo': _masterFileNo,
+        'markerId': _markerId,
+        ...data, // Spread the form data
+        'savedAt': DateTime.now().toIso8601String(),
+        'imageCount': uploadedImages.length,
+      };
+
+      // Convert to JSON string
+      final jsonString = jsonEncode(localData);
+
+      // Generate a unique key for this specific marker
+      final String key = 'lm_rental_evidence_${_masterFileNo}_$_markerId';
+
+      // Save to SharedPreferences
+      await prefs.setString(key, jsonString);
+
+      debugPrint('LM Rental Evidence data saved locally with key: $key');
+
+      // Show success message for local save
+      _showSuccessMessage('Rental evidence saved locally for this location!');
+    } catch (e) {
+      debugPrint('Error saving data locally: $e');
+      _showErrorMessage('Failed to save data locally. Please try again.');
+    }
+  }
+
+  // Submit method - validates and submits to backend
   void _validateAndSubmit() {
     setState(() {
       _isSubmitting = true;
@@ -159,14 +404,17 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
 
         // Send data to the backend
         _cubit.sendLmRentalEvidence(
-          masterFileId: "56249", // You can get this dynamically
+          landMiscellaneousMasterFileId: _masterFileId != null
+              ? int.tryParse(_masterFileId!) ?? 72
+              : 72, // Use provided master file ID or fallback to 72
           masterFileRefNo: _masterFileRefNoController.text,
           assessmentNo: _assessmentNoController.text,
           owner: _ownerController.text,
           occupier: _occupierController.text,
           description: _descriptionController.text,
-          floorRateSQFT: _floorRateController.text,
-          ratePerSqft: _ratePerSqftController.text,
+          floorRate: _floorRateController.text,
+          ratePer:
+              _ratePerSqftController.text, // This maps to ratePer in the API
           ratePerMonth: _ratePerMonthController.text,
           locationLongitude: _longitudeController.text,
           locationLatitude: _latitudeController.text,
@@ -319,7 +567,7 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
       child: Scaffold(
         // Custom app bar with a localized title.
         appBar: CustomAppBar(
-          title: "LM Rental Evidence",
+          title: "Rental Evidence",
         ),
         // Allows the entire view to be scrollable.
         body: SingleChildScrollView(
@@ -329,7 +577,11 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
               // Breadcrumb navigation.
               Breadcrumb(items: [
                 BreadcrumbItem(label: "Land Miscellaneous"),
-                BreadcrumbItem(label: AppString.masterFile.localize(context)!),
+                BreadcrumbItem(
+                  label: _masterFileNo != null
+                      ? "Master File - #$_masterFileNo"
+                      : AppString.masterFile.localize(context)!,
+                ),
                 BreadcrumbItem(label: "LM Rental Evidence Form"),
               ]),
               // LayoutBuilder used to determine the width constraints for form fields.
@@ -604,7 +856,12 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
                               // Cancel button.
                               CustomButton(
                                 text: AppString.cancel.localize(context) ?? '',
-                                onPressed: _isSubmitting ? null : () {},
+                                onPressed: _isSubmitting
+                                    ? null
+                                    : () {
+                                        Navigator.of(context)
+                                            .pop(); // Close the form
+                                      },
                                 backgroundColor: colors(context).colorGrey1 ??
                                     LightColorList.lightGrey50,
                               ),
@@ -612,18 +869,18 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
                                   ? const CircularProgressIndicator()
                                   : Row(
                                       children: [
-                                        // Save button.
+                                        // Save button - saves locally without redirection.
                                         CustomButton(
                                           text: AppString.save
                                                   .localize(context) ??
                                               '',
-                                          onPressed: _validateAndSubmit,
+                                          onPressed: _saveLocally,
                                           backgroundColor: colors(context)
                                                   .colorPrimary5 ??
                                               LightColorList.lightPrimary700,
                                         ),
                                         const SizedBox(width: 40),
-                                        // Send data button.
+                                        // Send data button - submits to backend.
                                         CustomButton(
                                           text: AppString.sendData
                                                   .localize(context) ??
@@ -650,20 +907,53 @@ class _LmRentalEvidencesViewState extends BasePageState<LmRentalEvidencesView> {
     ); // Closing BlocListener
   }
 
-  /// Handles post-success logic: show message, upload images, then navigate
+  /// Handles post-success logic: show message, upload images, then show success dialog
   Future<void> _handleSuccess(String reportId) async {
     setState(() {
       _isSubmitting = false;
     });
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('LM rental evidence submitted successfully!'),
-        backgroundColor: Colors.green,
-      ),
-    );
+
+    // Upload images first
     await uploadImages(reportId);
+
     if (!mounted) return;
-    context.go(Pages.routeMapScreen.toPath());
+
+    // Show success dialog
+    _showSuccessDialog();
+  }
+
+  /// Shows a success dialog and goes back to previous screen when dismissed
+  void _showSuccessDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: false, // Prevent dismissing by tapping outside
+      builder: (BuildContext dialogContext) {
+        return AlertDialog(
+          title: const Row(
+            children: [
+              Icon(
+                Icons.check_circle,
+                color: Colors.green,
+                size: 24,
+              ),
+              SizedBox(width: 8),
+              Text('Success'),
+            ],
+          ),
+          content: const Text('LM rental evidence data sent successfully!'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                // Close the dialog first
+                Navigator.of(dialogContext).pop();
+                context.pop(); // Use GoRouter's pop to safely go back
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   // Returns the cubit instance for managing state.

--- a/lib/application/pages/LMSalesEvidences/lm_sales_evidences_view.dart
+++ b/lib/application/pages/LMSalesEvidences/lm_sales_evidences_view.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:land_asset_valuation/app/base_view.dart';
 import 'package:land_asset_valuation/application/core/utils/app_colors/theme_data.dart';
 import 'package:land_asset_valuation/application/core/utils/app_strings.dart';
@@ -63,6 +64,37 @@ class _LmSalesEvidencesViewState extends BasePageState<LmSalesEvidencesView> {
   @override
   LmSalesEvidencesCubit getCubit() {
     return _cubit;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _extractNavigationData();
+  }
+
+  /// Extracts data passed from map navigation
+  void _extractNavigationData() {
+    final GoRouterState state = GoRouterState.of(context);
+    final queryParams = state.uri.queryParameters;
+
+    // Extract coordinates from query parameters (if coming from map marker)
+    final latStr = queryParams['latitude'];
+    final lngStr = queryParams['longitude'];
+
+    if (latStr != null && lngStr != null) {
+      _locationLatitudeController.text = latStr;
+      _locationLongitudeController.text = lngStr;
+      debugPrint(
+          "LmSalesEvidences: Auto-filled coordinates - Lat: $latStr, Lng: $lngStr");
+    }
+
+    // Extract master file number if available
+    final masterFileNo = queryParams['masterFileNo'];
+    if (masterFileNo != null) {
+      _masterFileRefController.text = masterFileNo;
+      debugPrint(
+          "LmSalesEvidences: Auto-filled master file ref: $masterFileNo");
+    }
   }
 
   /// Adds a newly picked image to the collection

--- a/lib/application/pages/MapScreen/map_screen.dart
+++ b/lib/application/pages/MapScreen/map_screen.dart
@@ -434,13 +434,62 @@ class _MapScreenState extends State<MapScreen> {
 
     switch (type) {
       case MapMarkerLoader.markerTypeRental:
-        targetPath = Pages.routeRentalEvidence.toPath();
+        // Context-aware navigation for Rental Evidence
+        if (source == 'landMiscellaneous') {
+          // Pass masterFileNo and coordinates as query parameters for LM Rental Evidence
+          final queryParams = <String, String>{};
+          if (_masterFileNo != null) {
+            queryParams['masterFileNo'] = _masterFileNo!;
+          }
+          if (_masterFileRefNo != null) {
+            queryParams['masterFileRefNo'] = _masterFileRefNo!;
+          }
+
+          // Add coordinates from the selected marker
+          if (_selectedMarkerForSketching != null) {
+            final coords = _selectedMarkerForSketching!.geometry.coordinates;
+            queryParams['latitude'] = coords.lat.toString();
+            queryParams['longitude'] = coords.lng.toString();
+            debugPrint(
+                "MapScreen: Adding coordinates to navigation - Lat: ${coords.lat}, Lng: ${coords.lng}");
+          }
+
+          final targetUri = Uri(
+            path: Pages.routeLmRentalEvidences.toPath(),
+            queryParameters: queryParams.isNotEmpty ? queryParams : null,
+          );
+          targetPath = targetUri.toString();
+          debugPrint(
+              "MapScreen: Navigating to LM Rental Evidence (source: $source, masterFileNo: $_masterFileNo, coordinates: ${_selectedMarkerForSketching?.geometry.coordinates})");
+        } else {
+          targetPath = Pages.routeRentalEvidence.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Rental Evidence (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeSales:
-        targetPath = Pages.routeLaSalesEvidence.toPath();
+        // Context-aware navigation for Sales Evidence
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmSalesEvidences.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Sales Evidence (source: $source)");
+        } else {
+          targetPath = Pages.routeLaSalesEvidence.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Sales Evidence (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeValuations:
-        targetPath = Pages.routePastValuation.toPath();
+        // Context-aware navigation for Past Valuations
+        if (source == 'landMiscellaneous') {
+          targetPath = Pages.routeLmPastValuations.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LM Past Valuations (source: $source)");
+        } else {
+          targetPath = Pages.routePastValuation.toPath();
+          debugPrint(
+              "MapScreen: Navigating to LA Past Valuations (source: $source)");
+        }
         break;
       case MapMarkerLoader.markerTypeBuildingRates:
         // Context-aware navigation for Building Rates

--- a/lib/data/models/lm_rental_evidences_model.dart
+++ b/lib/data/models/lm_rental_evidences_model.dart
@@ -2,14 +2,14 @@ import 'dart:convert';
 
 class LmRentalEvidencesModel {
   final int? id;
-  final String masterFileId;
+  final int landMiscellaneousMasterFileId;
   final String masterFileRefNo;
   final String assessmentNo;
   final String owner;
   final String occupier;
   final String description;
-  final String floorRateSQFT;
-  final String ratePerSqft;
+  final String floorRate;
+  final String ratePer;
   final String ratePerMonth;
   final String locationLongitude;
   final String locationLatitude;
@@ -20,14 +20,14 @@ class LmRentalEvidencesModel {
 
   LmRentalEvidencesModel({
     this.id,
-    required this.masterFileId,
+    required this.landMiscellaneousMasterFileId,
     required this.masterFileRefNo,
     required this.assessmentNo,
     required this.owner,
     required this.occupier,
     required this.description,
-    required this.floorRateSQFT,
-    required this.ratePerSqft,
+    required this.floorRate,
+    required this.ratePer,
     required this.ratePerMonth,
     required this.locationLongitude,
     required this.locationLatitude,
@@ -39,36 +39,34 @@ class LmRentalEvidencesModel {
 
   Map<String, dynamic> toJson() {
     return {
-      if (id != null) 'id': id,
-      'masterFileId': masterFileId,
       'masterFileRefNo': masterFileRefNo,
+      'landMiscellaneousMasterFileId': landMiscellaneousMasterFileId,
       'assessmentNo': assessmentNo,
       'owner': owner,
       'occupier': occupier,
       'description': description,
-      'floorRateSQFT': floorRateSQFT,
-      'ratePerSqft': ratePerSqft,
+      'floorRate': floorRate,
+      'ratePer': ratePer,
       'ratePerMonth': ratePerMonth,
       'locationLongitude': locationLongitude,
       'locationLatitude': locationLatitude,
       'headOfTerms': headOfTerms,
       'situation': situation,
       'remarks': remarks,
-      if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
     };
   }
 
   factory LmRentalEvidencesModel.fromJson(Map<String, dynamic> json) {
     return LmRentalEvidencesModel(
       id: json['id'],
-      masterFileId: json['masterFileId'] ?? '',
+      landMiscellaneousMasterFileId: json['landMiscellaneousMasterFileId'] ?? 0,
       masterFileRefNo: json['masterFileRefNo'] ?? '',
       assessmentNo: json['assessmentNo'] ?? '',
       owner: json['owner'] ?? '',
       occupier: json['occupier'] ?? '',
       description: json['description'] ?? '',
-      floorRateSQFT: json['floorRateSQFT'] ?? '',
-      ratePerSqft: json['ratePerSqft'] ?? '',
+      floorRate: json['floorRate'] ?? '',
+      ratePer: json['ratePer'] ?? '',
       ratePerMonth: json['ratePerMonth'] ?? '',
       locationLongitude: json['locationLongitude'] ?? '',
       locationLatitude: json['locationLatitude'] ?? '',

--- a/lib/data/repositories/lm_rental_evidences_repository_impl.dart
+++ b/lib/data/repositories/lm_rental_evidences_repository_impl.dart
@@ -20,7 +20,8 @@ class LmRentalEvidencesRepositoryImpl implements LmRentalEvidencesRepository {
       _logger.d(
           '======= LM RENTAL EVIDENCES REPOSITORY: SENDING TO REMOTE DATA SOURCE =======');
       _logger.d('Report ID: ${report.id}');
-      _logger.d('Master File ID: ${report.masterFileId}');
+      _logger.d(
+          'Land Miscellaneous Master File ID: ${report.landMiscellaneousMasterFileId}');
       _logger.d('Assessment No: ${report.assessmentNo}');
       _logger.d('Owner: ${report.owner}');
       _logger.d('Data being sent to API...');

--- a/lib/data/services/rental_evidence_service.dart
+++ b/lib/data/services/rental_evidence_service.dart
@@ -1,0 +1,97 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Service class for managing rental evidence data in SharedPreferences
+class RentalEvidenceService {
+  /// Clear all rental evidence data for a specific master file
+  /// This removes all entries with keys matching pattern: lm_rental_evidence_{masterFileNo}_*
+  Future<bool> clearRentalEvidencesForMasterFile(String masterFileNo) async {
+    try {
+      print('🗑️ Clearing rental evidences for master file: $masterFileNo');
+
+      final prefs = await SharedPreferences.getInstance();
+      final keys = prefs.getKeys();
+
+      // Filter keys that match the rental evidence pattern for this master file
+      final keyPrefix = 'lm_rental_evidence_${masterFileNo}_';
+      final keysToRemove =
+          keys.where((key) => key.startsWith(keyPrefix)).toList();
+
+      print(
+          '   Found ${keysToRemove.length} rental evidence entries to remove');
+      print('   Keys to remove: $keysToRemove');
+
+      // Remove all matching keys
+      for (final key in keysToRemove) {
+        await prefs.remove(key);
+        print('   ✅ Removed key: $key');
+      }
+
+      print('✅ Rental evidences cleared for master file: $masterFileNo');
+      return true;
+    } catch (e) {
+      print('❌ Error clearing rental evidences for master file: $e');
+      return false;
+    }
+  }
+
+  /// Clear all rental evidence data (useful for debugging or complete reset)
+  Future<bool> clearAllRentalEvidences() async {
+    try {
+      print('🗑️ Clearing all rental evidence data');
+
+      final prefs = await SharedPreferences.getInstance();
+      final keys = prefs.getKeys();
+
+      // Filter keys that match any rental evidence pattern
+      final keysToRemove =
+          keys.where((key) => key.startsWith('lm_rental_evidence_')).toList();
+
+      print(
+          '   Found ${keysToRemove.length} rental evidence entries to remove');
+
+      // Remove all matching keys
+      for (final key in keysToRemove) {
+        await prefs.remove(key);
+      }
+
+      print('✅ All rental evidences cleared');
+      return true;
+    } catch (e) {
+      print('❌ Error clearing all rental evidences: $e');
+      return false;
+    }
+  }
+
+  /// Get all rental evidence keys for a specific master file (useful for debugging)
+  Future<List<String>> getRentalEvidenceKeysForMasterFile(
+      String masterFileNo) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final keys = prefs.getKeys();
+
+      final keyPrefix = 'lm_rental_evidence_${masterFileNo}_';
+      final matchingKeys =
+          keys.where((key) => key.startsWith(keyPrefix)).toList();
+
+      print(
+          '📋 Found ${matchingKeys.length} rental evidence keys for master file $masterFileNo');
+      print('   Keys: $matchingKeys');
+
+      return matchingKeys;
+    } catch (e) {
+      print('❌ Error getting rental evidence keys: $e');
+      return [];
+    }
+  }
+
+  /// Get count of rental evidence entries for a specific master file
+  Future<int> getRentalEvidenceCountForMasterFile(String masterFileNo) async {
+    try {
+      final keys = await getRentalEvidenceKeysForMasterFile(masterFileNo);
+      return keys.length;
+    } catch (e) {
+      print('❌ Error getting rental evidence count: $e');
+      return 0;
+    }
+  }
+}

--- a/lib/injection.dart
+++ b/lib/injection.dart
@@ -180,6 +180,9 @@ import 'package:land_asset_valuation/domain/repositories/la_lot_repository.dart'
 import 'package:land_asset_valuation/domain/usecases/save_la_lot_usecase.dart';
 import 'package:land_asset_valuation/domain/usecases/get_la_lots_usecase.dart';
 
+// Services
+import 'package:land_asset_valuation/data/services/rental_evidence_service.dart';
+
 final injection = GetIt.I;
 
 Future<void> init() async {
@@ -720,4 +723,9 @@ Future<void> init() async {
   injection.registerLazySingleton(
     () => GetLALotsUseCase(injection()),
   );
+
+  // ------------------------------
+  // Services
+  // ------------------------------
+  injection.registerLazySingleton(() => RentalEvidenceService());
 }

--- a/test/models/lm_rental_evidences_model_test.dart
+++ b/test/models/lm_rental_evidences_model_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:land_asset_valuation/data/models/lm_rental_evidences_model.dart';
+
+void main() {
+  group('LmRentalEvidencesModel Tests', () {
+    test('should create model with correct data types', () {
+      // Arrange
+      final model = LmRentalEvidencesModel(
+        landMiscellaneousMasterFileId: 72,
+        masterFileRefNo: 'Metro 2/LA/52417',
+        assessmentNo: 'test_assessment',
+        owner: 'test_owner',
+        occupier: 'test_occupier',
+        description: 'test_description',
+        floorRate: '100.50',
+        ratePer: '200.75',
+        ratePerMonth: '300.25',
+        locationLongitude: '79.8612',
+        locationLatitude: '6.9271',
+        headOfTerms: 'test_terms',
+        situation: 'test_situation',
+        remarks: 'test_remarks',
+      );
+
+      // Assert
+      expect(model.landMiscellaneousMasterFileId, 72);
+      expect(model.masterFileRefNo, 'Metro 2/LA/52417');
+      expect(model.assessmentNo, 'test_assessment');
+      expect(model.floorRate, '100.50');
+      expect(model.ratePer, '200.75');
+      expect(model.ratePerMonth, '300.25');
+    });
+
+    test('should serialize to JSON with correct API format', () {
+      // Arrange
+      final model = LmRentalEvidencesModel(
+        landMiscellaneousMasterFileId: 72,
+        masterFileRefNo: 'Metro 2/LA/52417',
+        assessmentNo: 'test_assessment',
+        owner: 'test_owner',
+        occupier: 'test_occupier',
+        description: 'test_description',
+        floorRate: '100.50',
+        ratePer: '200.75',
+        ratePerMonth: '300.25',
+        locationLongitude: '79.8612',
+        locationLatitude: '6.9271',
+        headOfTerms: 'test_terms',
+        situation: 'test_situation',
+        remarks: 'test_remarks',
+      );
+
+      // Act
+      final json = model.toJson();
+
+      // Assert - Check all expected API fields are present
+      expect(json['masterFileRefNo'], 'Metro 2/LA/52417');
+      expect(json['landMiscellaneousMasterFileId'], 72);
+      expect(json['assessmentNo'], 'test_assessment');
+      expect(json['owner'], 'test_owner');
+      expect(json['occupier'], 'test_occupier');
+      expect(json['description'], 'test_description');
+      expect(json['floorRate'], '100.50');
+      expect(json['ratePer'], '200.75');
+      expect(json['ratePerMonth'], '300.25');
+      expect(json['locationLongitude'], '79.8612');
+      expect(json['locationLatitude'], '6.9271');
+      expect(json['headOfTerms'], 'test_terms');
+      expect(json['situation'], 'test_situation');
+      expect(json['remarks'], 'test_remarks');
+
+      // Ensure no old field names are present
+      expect(json.containsKey('masterFileId'), false);
+      expect(json.containsKey('floorRateSQFT'), false);
+      expect(json.containsKey('ratePerSqft'), false);
+    });
+
+    test('should deserialize from JSON response format', () {
+      // Arrange - Sample response from your API specification
+      final jsonResponse = {
+        'id': 8,
+        'reportId': 115,
+        'masterFileRefNo': 'Metro 2/LA/52417',
+        'landMiscellaneousMasterFileId': 72,
+        'assessmentNo': 'test_assessment',
+        'owner': 'test_owner',
+        'occupier': 'test_occupier',
+        'description': 'test_description',
+        'floorRate': '100.50',
+        'ratePer': '200.75',
+        'ratePerMonth': '300.25',
+        'locationLongitude': '79.8612',
+        'locationLatitude': '6.9271',
+        'headOfTerms': 'test_terms',
+        'situation': 'test_situation',
+        'remarks': 'test_remarks',
+      };
+
+      // Act
+      final model = LmRentalEvidencesModel.fromJson(jsonResponse);
+
+      // Assert
+      expect(model.id, 8);
+      expect(model.landMiscellaneousMasterFileId, 72);
+      expect(model.masterFileRefNo, 'Metro 2/LA/52417');
+      expect(model.assessmentNo, 'test_assessment');
+      expect(model.floorRate, '100.50');
+      expect(model.ratePer, '200.75');
+      expect(model.ratePerMonth, '300.25');
+    });
+
+    test('should handle missing fields in fromJson', () {
+      // Arrange - Minimal JSON
+      final jsonResponse = {
+        'landMiscellaneousMasterFileId': 72,
+        'masterFileRefNo': 'Metro 2/LA/52417',
+      };
+
+      // Act
+      final model = LmRentalEvidencesModel.fromJson(jsonResponse);
+
+      // Assert
+      expect(model.landMiscellaneousMasterFileId, 72);
+      expect(model.masterFileRefNo, 'Metro 2/LA/52417');
+      expect(model.assessmentNo, '');
+      expect(model.owner, '');
+      expect(model.floorRate, '');
+      expect(model.ratePer, '');
+    });
+  });
+}

--- a/test/services/rental_evidence_service_test.dart
+++ b/test/services/rental_evidence_service_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:land_asset_valuation/data/services/rental_evidence_service.dart';
+
+void main() {
+  group('RentalEvidenceService Tests', () {
+    late RentalEvidenceService rentalEvidenceService;
+
+    setUp(() {
+      // Set up mock SharedPreferences
+      SharedPreferences.setMockInitialValues({});
+      rentalEvidenceService = RentalEvidenceService();
+    });
+
+    test('should clear rental evidences for a specific master file', () async {
+      // Set up test data - simulate existing rental evidence entries
+      final prefs = await SharedPreferences.getInstance();
+
+      // Add some test rental evidence entries for different master files
+      await prefs.setString(
+          'lm_rental_evidence_MF001_marker1', '{"data": "test1"}');
+      await prefs.setString(
+          'lm_rental_evidence_MF001_marker2', '{"data": "test2"}');
+      await prefs.setString(
+          'lm_rental_evidence_MF002_marker1', '{"data": "test3"}');
+      await prefs.setString('other_key', '{"data": "other"}');
+
+      // Verify initial state
+      expect(
+          prefs
+              .getKeys()
+              .where((key) => key.startsWith('lm_rental_evidence_'))
+              .length,
+          3);
+
+      // Clear rental evidences for MF001
+      final result = await rentalEvidenceService
+          .clearRentalEvidencesForMasterFile('MF001');
+
+      // Verify result
+      expect(result, true);
+
+      // Verify that only MF001 entries were removed
+      final remainingKeys = prefs.getKeys();
+      expect(remainingKeys.contains('lm_rental_evidence_MF001_marker1'), false);
+      expect(remainingKeys.contains('lm_rental_evidence_MF001_marker2'), false);
+      expect(remainingKeys.contains('lm_rental_evidence_MF002_marker1'), true);
+      expect(remainingKeys.contains('other_key'), true);
+    });
+
+    test('should get count of rental evidence entries for master file',
+        () async {
+      final prefs = await SharedPreferences.getInstance();
+
+      // Add test data
+      await prefs.setString(
+          'lm_rental_evidence_MF001_marker1', '{"data": "test1"}');
+      await prefs.setString(
+          'lm_rental_evidence_MF001_marker2', '{"data": "test2"}');
+      await prefs.setString(
+          'lm_rental_evidence_MF002_marker1', '{"data": "test3"}');
+
+      // Test count
+      final count = await rentalEvidenceService
+          .getRentalEvidenceCountForMasterFile('MF001');
+      expect(count, 2);
+
+      final count2 = await rentalEvidenceService
+          .getRentalEvidenceCountForMasterFile('MF002');
+      expect(count2, 1);
+
+      final count3 = await rentalEvidenceService
+          .getRentalEvidenceCountForMasterFile('MF999');
+      expect(count3, 0);
+    });
+
+    test('should clear all rental evidences', () async {
+      final prefs = await SharedPreferences.getInstance();
+
+      // Add test data
+      await prefs.setString(
+          'lm_rental_evidence_MF001_marker1', '{"data": "test1"}');
+      await prefs.setString(
+          'lm_rental_evidence_MF002_marker1', '{"data": "test2"}');
+      await prefs.setString('other_key', '{"data": "other"}');
+
+      // Clear all rental evidences
+      final result = await rentalEvidenceService.clearAllRentalEvidences();
+
+      // Verify result
+      expect(result, true);
+
+      // Verify that only rental evidence entries were removed
+      final remainingKeys = prefs.getKeys();
+      expect(
+          remainingKeys
+              .where((key) => key.startsWith('lm_rental_evidence_'))
+              .length,
+          0);
+      expect(remainingKeys.contains('other_key'), true);
+    });
+  });
+}


### PR DESCRIPTION
- Implement context-aware navigation in AssetMapScreen for different evidence types based on source.
- Add controllers for longitude, latitude, and master file reference in LMPastValuations view.
- Update LmRentalEvidencesCubit to use landMiscellaneousMasterFileId instead of masterFileId.
- Modify LmRentalEvidences view to extract navigation data and pre-fill fields from query parameters.
- Introduce local save functionality in LmRentalEvidences view for offline data storage.
- Create RentalEvidenceService for managing rental evidence data in SharedPreferences.
- Update LmRentalEvidencesModel to reflect changes in data structure.
- Add tests for LmRentalEvidencesModel and RentalEvidenceService to ensure correct functionality.